### PR TITLE
Remove go.mod replace directive, use json fork directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"github.com/veqryn/json"
+	"github.com/veqryn/json/jsontext"
 	slogjson "github.com/veqryn/slog-json"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/veqryn/slog-json
 
 go 1.21
 
-require github.com/go-json-experiment/json v0.0.0-20231102232822-2e55bd4e08b0
-
-replace github.com/go-json-experiment/json => github.com/veqryn/json v0.0.0-20240316052440-58057466c1d8
+require github.com/veqryn/json v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/veqryn/json v0.0.0-20240316052440-58057466c1d8 h1:/M2CLy/WVu7XGnoSVwL+/wwgtvqsuvqtg32VA6pEpcM=
-github.com/veqryn/json v0.0.0-20240316052440-58057466c1d8/go.mod h1:6daplAwHHGbUGib4990V3Il26O0OC4aRyvewaaAihaA=
+github.com/veqryn/json v0.1.0 h1:/VRRuG8TKnyIzuBf2jw5rn9oFrzMNxqyv0BekvDyLWM=
+github.com/veqryn/json v0.1.0/go.mod h1:d7xTdEVXlquK1eJxQic/C8+Jso+K/q7rR91kjlcdgYQ=

--- a/handler.go
+++ b/handler.go
@@ -14,8 +14,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"github.com/veqryn/json"
+	"github.com/veqryn/json/jsontext"
 	"github.com/veqryn/slog-json/internal/buffer"
 )
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
+	"github.com/veqryn/json"
+	"github.com/veqryn/json/jsontext"
 	"github.com/veqryn/slog-json/internal/buffer"
 )
 


### PR DESCRIPTION
Remove go.mod replace directive, use json fork directly.
(Replace directives don't work beyond your active repo, which means they don't work for users of this library.)